### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ return [$b, $c, 'hello', [1, 2]]
 ```
 
 
-###Just Enjoy It!
+### Just Enjoy It!
 
 
 ### Acknowledgements


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
